### PR TITLE
* Fixes validation issue with POST requests to /unavailabilities

### DIFF
--- a/microservices/backend/openapi_server/controllers/unavailability_controller.py
+++ b/microservices/backend/openapi_server/controllers/unavailability_controller.py
@@ -53,4 +53,5 @@ def unavailabilities_post(unavailabilities_post_request=None):  # noqa: E501
     """
     if connexion.request.is_json:
         unavailabilities_post_request = UnavailabilitiesPostRequest.from_dict(connexion.request.get_json())  # noqa: E501
+    
     return 'do some magic!'

--- a/microservices/backend/openapi_server/models/new_recurring_unavailability.py
+++ b/microservices/backend/openapi_server/models/new_recurring_unavailability.py
@@ -120,7 +120,7 @@ class NewRecurringUnavailability(Model):
         """
         if start_date is None:
             raise ValueError("Invalid value for `start_date`, must not be `None`")  # noqa: E501
-        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
+        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
             raise ValueError("Invalid value for `start_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._start_date = start_date
@@ -147,7 +147,7 @@ class NewRecurringUnavailability(Model):
         """
         if end_date is None:
             raise ValueError("Invalid value for `end_date`, must not be `None`")  # noqa: E501
-        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
+        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
             raise ValueError("Invalid value for `end_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._end_date = end_date
@@ -222,7 +222,7 @@ class NewRecurringUnavailability(Model):
         """
         if recurrence is None:
             raise ValueError("Invalid value for `recurrence`, must not be `None`")  # noqa: E501
-        if recurrence is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', recurrence):  # noqa: E501
+        if recurrence is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', recurrence):  # noqa: E501
             raise ValueError("Invalid value for `recurrence`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._recurrence = recurrence

--- a/microservices/backend/openapi_server/models/new_recurring_unavailability_all_of.py
+++ b/microservices/backend/openapi_server/models/new_recurring_unavailability_all_of.py
@@ -66,7 +66,7 @@ class NewRecurringUnavailabilityAllOf(Model):
         """
         if recurrence is None:
             raise ValueError("Invalid value for `recurrence`, must not be `None`")  # noqa: E501
-        if recurrence is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', recurrence):  # noqa: E501
+        if recurrence is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', recurrence):  # noqa: E501
             raise ValueError("Invalid value for `recurrence`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._recurrence = recurrence

--- a/microservices/backend/openapi_server/models/new_unavailability.py
+++ b/microservices/backend/openapi_server/models/new_unavailability.py
@@ -29,7 +29,7 @@ class NewUnavailability(Model):
         :param end_date: The end_date of this NewUnavailability.  # noqa: E501
         :type end_date: str
         :param owner: The owner of this NewUnavailability.  # noqa: E501
-        :type owner: UpdateUnavailabilityOwner
+        :type owner: str
         :param type: The type of this NewUnavailability.  # noqa: E501
         :type type: str
         """
@@ -37,7 +37,7 @@ class NewUnavailability(Model):
             'item': str,
             'start_date': str,
             'end_date': str,
-            'owner': UpdateUnavailabilityOwner,
+            'owner': str,
             'type': str
         }
 
@@ -115,7 +115,7 @@ class NewUnavailability(Model):
         """
         if start_date is None:
             raise ValueError("Invalid value for `start_date`, must not be `None`")  # noqa: E501
-        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
+        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
             raise ValueError("Invalid value for `start_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._start_date = start_date
@@ -142,7 +142,7 @@ class NewUnavailability(Model):
         """
         if end_date is None:
             raise ValueError("Invalid value for `end_date`, must not be `None`")  # noqa: E501
-        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
+        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
             raise ValueError("Invalid value for `end_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._end_date = end_date
@@ -163,7 +163,7 @@ class NewUnavailability(Model):
 
 
         :param owner: The owner of this NewUnavailability.
-        :type owner: UpdateUnavailabilityOwner
+        :type owner: str
         """
 
         self._owner = owner

--- a/microservices/backend/openapi_server/models/recurring_unavailability.py
+++ b/microservices/backend/openapi_server/models/recurring_unavailability.py
@@ -125,7 +125,7 @@ class RecurringUnavailability(Model):
         """
         if start_date is None:
             raise ValueError("Invalid value for `start_date`, must not be `None`")  # noqa: E501
-        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
+        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
             raise ValueError("Invalid value for `start_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._start_date = start_date
@@ -152,7 +152,7 @@ class RecurringUnavailability(Model):
         """
         if end_date is None:
             raise ValueError("Invalid value for `end_date`, must not be `None`")  # noqa: E501
-        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
+        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
             raise ValueError("Invalid value for `end_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._end_date = end_date
@@ -227,7 +227,7 @@ class RecurringUnavailability(Model):
         """
         if recurrence is None:
             raise ValueError("Invalid value for `recurrence`, must not be `None`")  # noqa: E501
-        if recurrence is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', recurrence):  # noqa: E501
+        if recurrence is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', recurrence):  # noqa: E501
             raise ValueError("Invalid value for `recurrence`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._recurrence = recurrence

--- a/microservices/backend/openapi_server/models/unavailabilities_post_request.py
+++ b/microservices/backend/openapi_server/models/unavailabilities_post_request.py
@@ -33,7 +33,7 @@ class UnavailabilitiesPostRequest(Model):
         :param end_date: The end_date of this UnavailabilitiesPostRequest.  # noqa: E501
         :type end_date: str
         :param owner: The owner of this UnavailabilitiesPostRequest.  # noqa: E501
-        :type owner: UpdateUnavailabilityOwner
+        :type owner: str
         :param type: The type of this UnavailabilitiesPostRequest.  # noqa: E501
         :type type: str
         :param recurrence: The recurrence of this UnavailabilitiesPostRequest.  # noqa: E501
@@ -43,7 +43,7 @@ class UnavailabilitiesPostRequest(Model):
             'item': str,
             'start_date': str,
             'end_date': str,
-            'owner': UpdateUnavailabilityOwner,
+            'owner': str,
             'type': str,
             'recurrence': str
         }
@@ -124,7 +124,7 @@ class UnavailabilitiesPostRequest(Model):
         """
         if start_date is None:
             raise ValueError("Invalid value for `start_date`, must not be `None`")  # noqa: E501
-        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
+        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
             raise ValueError("Invalid value for `start_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._start_date = start_date
@@ -151,7 +151,7 @@ class UnavailabilitiesPostRequest(Model):
         """
         if end_date is None:
             raise ValueError("Invalid value for `end_date`, must not be `None`")  # noqa: E501
-        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
+        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
             raise ValueError("Invalid value for `end_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._end_date = end_date
@@ -162,7 +162,7 @@ class UnavailabilitiesPostRequest(Model):
 
 
         :return: The owner of this UnavailabilitiesPostRequest.
-        :rtype: UpdateUnavailabilityOwner
+        :rtype: str
         """
         return self._owner
 
@@ -172,7 +172,7 @@ class UnavailabilitiesPostRequest(Model):
 
 
         :param owner: The owner of this UnavailabilitiesPostRequest.
-        :type owner: UpdateUnavailabilityOwner
+        :type owner: str
         """
 
         self._owner = owner
@@ -226,7 +226,7 @@ class UnavailabilitiesPostRequest(Model):
         """
         if recurrence is None:
             raise ValueError("Invalid value for `recurrence`, must not be `None`")  # noqa: E501
-        if recurrence is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', recurrence):  # noqa: E501
+        if recurrence is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', recurrence):  # noqa: E501
             raise ValueError("Invalid value for `recurrence`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._recurrence = recurrence

--- a/microservices/backend/openapi_server/models/unavailability.py
+++ b/microservices/backend/openapi_server/models/unavailability.py
@@ -130,7 +130,7 @@ class Unavailability(Model):
         """
         if start_date is None:
             raise ValueError("Invalid value for `start_date`, must not be `None`")  # noqa: E501
-        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
+        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
             raise ValueError("Invalid value for `start_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._start_date = start_date
@@ -157,7 +157,7 @@ class Unavailability(Model):
         """
         if end_date is None:
             raise ValueError("Invalid value for `end_date`, must not be `None`")  # noqa: E501
-        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
+        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
             raise ValueError("Invalid value for `end_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._end_date = end_date

--- a/microservices/backend/openapi_server/models/update_unavailability.py
+++ b/microservices/backend/openapi_server/models/update_unavailability.py
@@ -29,7 +29,7 @@ class UpdateUnavailability(Model):
         :param end_date: The end_date of this UpdateUnavailability.  # noqa: E501
         :type end_date: str
         :param owner: The owner of this UpdateUnavailability.  # noqa: E501
-        :type owner: UpdateUnavailabilityOwner
+        :type owner: str
         :param type: The type of this UpdateUnavailability.  # noqa: E501
         :type type: str
         """
@@ -37,7 +37,7 @@ class UpdateUnavailability(Model):
             'item': str,
             'start_date': str,
             'end_date': str,
-            'owner': UpdateUnavailabilityOwner,
+            'owner': str,
             'type': str
         }
 
@@ -111,7 +111,7 @@ class UpdateUnavailability(Model):
         :param start_date: The start_date of this UpdateUnavailability.
         :type start_date: str
         """
-        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
+        if start_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', start_date):  # noqa: E501
             raise ValueError("Invalid value for `start_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._start_date = start_date
@@ -136,7 +136,7 @@ class UpdateUnavailability(Model):
         :param end_date: The end_date of this UpdateUnavailability.
         :type end_date: str
         """
-        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
+        if end_date is not None and not re.search(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$', end_date):  # noqa: E501
             raise ValueError("Invalid value for `end_date`, must be a follow pattern or equal to `/^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$/`")  # noqa: E501
 
         self._end_date = end_date
@@ -157,7 +157,7 @@ class UpdateUnavailability(Model):
 
 
         :param owner: The owner of this UpdateUnavailability.
-        :type owner: UpdateUnavailabilityOwner
+        :type owner: str
         """
 
         self._owner = owner

--- a/microservices/backend/openapi_server/openapi/openapi.yaml
+++ b/microservices/backend/openapi_server/openapi/openapi.yaml
@@ -641,7 +641,7 @@ components:
     datetime15min:
       description: "date-time string with 15-minute interval, e.g., 2023-04-02t12:00:00"
       example: 2023-04-02t15:00:00
-      pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$"
+      pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$"
       title: datetime15min
       type: string
     error:
@@ -760,7 +760,6 @@ components:
       required:
       - endDate
       - item
-      - room
       - startDate
       - type
       title: newUnavailability
@@ -846,17 +845,21 @@ components:
         startDate:
           description: "date-time string with 15-minute interval, e.g., 2023-04-02t12:00:00"
           example: 2023-04-02t15:00:00
-          pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$"
+          pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$"
           title: datetime15min
           type: string
         endDate:
           description: "date-time string with 15-minute interval, e.g., 2023-04-02t12:00:00"
           example: 2023-04-02t15:00:00
-          pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$"
+          pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$"
           title: datetime15min
           type: string
         owner:
-          $ref: '#/components/schemas/updateUnavailability_owner'
+          description: |
+            the id of the owner of the unavailability.
+            It can be a group or a user
+          type: string
+          title: owner
         type:
           enum:
           - maintenance
@@ -972,10 +975,12 @@ components:
           $ref: '#/components/schemas/item'
       title: _items_post_201_response
     _unavailabilities_post_request:
+      $ref: '#/components/schemas/_unavailabilities_post_oneOf'
+      title: _unavailabilities_post_request
+    _unavailabilities_post_oneOf:
       oneOf:
       - $ref: '#/components/schemas/newUnavailability'
       - $ref: '#/components/schemas/newRecurringUnavailability'
-      title: _unavailabilities_post_request
     _unavailabilities_post_201_response:
       example:
         unavailability: null
@@ -1126,7 +1131,7 @@ components:
         recurrence:
           description: "date-time string with 15-minute interval, e.g., 2023-04-02t12:00:00"
           example: 2023-04-02t15:00:00
-          pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}t([01][0-9]|2[0-3]):(00|15|30|45):00$"
+          pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}[tT]([01][0-9]|2[0-3]):(00|15|30|45):00$"
           title: datetime15min
           type: string
       required:


### PR DESCRIPTION
This query should work:
```
curl --request POST   --url http://localhost:8080/unavailabilities   --header 'authorization: Bearer $TOKEN'   --header 'Content-Type: application/json'   --data '{"endDate": "2023-04-02T15:00:00", "item": "item-046b6c7f-0b8a-43b9-b35d-6489e6daee91", "owner": "group-dd297b45-464a-4d9f-8a7d-9dfe4fed3fd8", "startDate": "2023-04-02T15:00:00", "type": "booking"}'
```

Note that there is no 'Z' at the end